### PR TITLE
[CO-152] - Fix chart-logging test and cleanup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,7 @@ clean_test:
   image: $KUBECTL_IMAGE
   stage: clean
   allow_failure: true
+  when: always
   only:
     - tags
     - branches

--- a/build/test.sh
+++ b/build/test.sh
@@ -22,6 +22,9 @@ helm lint ${CHART_NAME}
 
 helm install --replace --name ${RELEASE} --namespace ${NAMESPACE} ./${CHART_NAME}
 
+echo Waiting for install to complete
+sleep ${INSTALL_WAIT}
+
 # if there are tests, run them against the installed chart
 if [[ -d ${CHART_NAME}/templates/tests ]]; then
   echo Testing release ${RELEASE}

--- a/logging/templates/NOTES.txt
+++ b/logging/templates/NOTES.txt
@@ -1,16 +1,28 @@
 This chart will take some time for elasticsearch to initialize.
 
 To see all deployed components:
+
   kubectl get all -n {{.Release.Namespace}} 
 
 Kibana:
-  To get the external address of the kibana server you can run following
-  export KIBANA_HOST=$(kubectl get svc/{{index .Values "kibana-chart" "name"}} -n {{.Release.Namespace}} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+  To get the external address of the kibana server you can run following:
+
+  export KIBANA_HOST=$(kubectl get svc/{{index .Values "kibana-chart" "name"}} -n {{.Release.Namespace}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
   echo http://${KIBANA_HOST}:{{index .Values "kibana-chart" "port"}}
 
 Elasticsearch:
-  - curl http://{{index .Values "elasticsearch-chart" "name"}}:{{index .Values "elasticsearch-chart" "port"}}/_cluster/health"]
+
+  Since elasticsearch is not exposed externally you can view the following resources:
+
+  # show stateful sets
+  kubectl describe statefulset/{{index .Values "elasticsearch-chart" "data_name"}} -n {{.Release.Namespace}}
+  kubectl describe statefulset/{{index .Values "elasticsearch-chart" "master_name"}} -n {{.Release.Namespace}}
+
+  # show associated pods
+  kubectl get po -l app=elasticsearch -n {{.Release.Namespace}}
 
 Curator:
+
   - schedule: {{.Values.curator.schedule}}
   - description: {{.Values.curator.description}}


### PR DESCRIPTION
Fixing chart test by waiting for install to complete. Also set the test clean job to always execute.

This can be verified by a successful Gitlab build. Additionally the clean activity can be verified by checking the resources in the namespace _logging-test_ have been properly cleaned and removed.