### PR TITLE
rev versions to get limits and requests for all

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -21,7 +21,7 @@ fi
 
 helm lint ${CHART_NAME}
 
-helm install --replace --name ${RELEASE} --namespace ${NAMESPACE} ./${CHART_NAME} --set name=elasticsearch-${CI_JOB_ID}
+helm install --replace --name ${RELEASE} --namespace ${NAMESPACE} ./${CHART_NAME} --set elasticsearch_chart.name=elasticsearch-${CI_JOB_ID}
 
 echo Waiting for install to complete
 sleep ${INSTALL_WAIT}

--- a/logging/requirements.yaml
+++ b/logging/requirements.yaml
@@ -7,10 +7,10 @@ appr:
   version: 0.0.2-0
 - name: quay.io/samsung_cnct/curator
   repository: appr://
-  version: 0.0.2-0
+  version: 0.0.3-0
 - name: quay.io/samsung_cnct/kibana-chart
   repository: appr://
   version: 0.1.1-0
 - name: quay.io/samsung_cnct/eventrouter
   repository: appr://
-  version: 0.0.2-0
+  version: 0.0.3-0

--- a/logging/requirements.yaml
+++ b/logging/requirements.yaml
@@ -1,16 +1,16 @@
 appr:
 - name: quay.io/samsung_cnct/fluent-bit
   repository: appr://
-  version: 0.0.1-50
+  version: 0.0.2-0
 - name: quay.io/samsung_cnct/elasticsearch-chart
   repository: appr://
   version: 0.0.2-0
 - name: quay.io/samsung_cnct/curator
   repository: appr://
-  version: 0.0.1-47
+  version: 0.0.2-0
 - name: quay.io/samsung_cnct/kibana-chart
   repository: appr://
-  version: 0.1.0-0
+  version: 0.1.1-0
 - name: quay.io/samsung_cnct/eventrouter
   repository: appr://
-  version: 0.0.1-40
+  version: 0.0.2-0

--- a/logging/requirements.yaml
+++ b/logging/requirements.yaml
@@ -10,7 +10,7 @@ appr:
   version: 0.0.3-0
 - name: quay.io/samsung_cnct/kibana-chart
   repository: appr://
-  version: 0.1.1-0
+  version: 0.1.2-0
 - name: quay.io/samsung_cnct/eventrouter
   repository: appr://
   version: 0.0.3-0


### PR DESCRIPTION
chart-logging is a collection of subcharts and values, it has no application templates of its own.

the commit only alters the version numbers for most of the charts.  the versions themselves are providing 'limits' and 'request' values for all pods deployed by the subcharts.