### PR TITLE
add blurb for CI/CD of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This project is built with the [helm application registry](https://github.com/ap
 Please see the [CI definition](.gitlab-ci.yml) and the [dependency management script](build/dependency_mgmt.sh) for details.
 
 ## CI system
-This repository uses [gitlab ci](https://about.gitlab.com/features/gitlab-ci-cd/) for CI.  The gitlab ci config file sets a number of tests to be run for each commit to an open PR, a merge to master and for a pushed tag.  A merge to master or a new tag will create new packaged versions in the alpha and stable channels, respectively, and will deploy to staging and production clusters.  Specifics on these processes can be found in .gitlab-ci.yml at the top level of this repository.  
+This repository uses [gitlab ci](https://about.gitlab.com/features/gitlab-ci-cd/) for CI.  The gitlab ci config file sets a number of tests to be run for each commit to an open PR, a merge to master and for a pushed tag.  A merge to master will create a new packaged version in the alpha channel and will deploy to the staging cluster.  Pushing a new tag will create a new packaged version in the stable channel and will deploy to the production cluster. Specifics on these processes can be found in .gitlab-ci.yml at the top level of this repository.  
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ This project is built with the [helm application registry](https://github.com/ap
 
 Please see the [CI definition](.gitlab-ci.yml) and the [dependency management script](build/dependency_mgmt.sh) for details.
 
+## CI system
+This repository uses [gitlab ci](https://about.gitlab.com/features/gitlab-ci-cd/) for CI.  The gitlab ci config file sets a number of tests to be run for each commit to an open PR, a merge to master and for a pushed tag.  A merge to master or a new tag will create new packaged versions in the alpha and stable channels, respectively, and will deploy to staging and production clusters.  Specifics on these processes can be found in .gitlab-ci.yml at the top level of this repository.  
+
 ## Contributing
 
 1. Fork it!


### PR DESCRIPTION
its a breadcrumb for what should happen. mostly for internal
purposes but its open source so anyone should be able to run this
in their own gitlab-ci instance.