### PR TITLE
add CI_JOB_ID to chart name values for fluentbit and eventrouter

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -21,7 +21,8 @@ fi
 
 helm lint ${CHART_NAME}
 
-helm install --replace --name ${RELEASE} --namespace ${NAMESPACE} ./${CHART_NAME} --set elasticsearch-chart.name=elasticsearch-${CI_JOB_ID}
+helm install --replace --name ${RELEASE} --namespace ${NAMESPACE} ./${CHART_NAME} --set elasticsearch-chart.name=elasticsearch-${CI_JOB_ID} \
+             --set eventrouter.name=eventrouter-${CI_JOB_ID} --set fluent-bit.name=fluent-bit-${CI_JOB_ID}
 
 echo Waiting for install to complete
 sleep ${INSTALL_WAIT}


### PR DESCRIPTION
both fluentbit and eventrouter have clusterrolebindings to enable
them to do their jobs (read all cluster events, read all cluster
logs).  For testing this means we have been having name collisions
between CI runs and the long running instance.  this should resolve
them